### PR TITLE
feat: updated banner display logic

### DIFF
--- a/apps/web/features/banner/banner.tsx
+++ b/apps/web/features/banner/banner.tsx
@@ -3,6 +3,7 @@
 import type { bannerSelection } from '@/sanity/selections/banner';
 import type { TypeFromSelection } from 'groqd';
 import Image from 'next/image';
+import { usePathname } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import { CustomUrl } from '@/components/custom-url';
@@ -23,14 +24,22 @@ interface BannerProps {
 export default function Banner({ banner }: BannerProps) {
   const [isBannerClosed, setIsBannerClosed] = useState(true);
 
+  const pathname = usePathname();
+
   useEffect(() => {
-    async function checkBannerCookie() {
+    async function checkBannerCookieAndPathname() {
       const cookie = await window.cookieStore.get('polkadot_banner_closed');
       setIsBannerClosed(!!cookie);
+
+      const currentPageSlugWithSlashes = `/${banner?.link?.internal?.slug}/`;
+
+      if (currentPageSlugWithSlashes === pathname) {
+        setIsBannerClosed(true);
+      }
     }
 
-    checkBannerCookie();
-  }, []);
+    checkBannerCookieAndPathname();
+  }, [banner?.link?.internal?.slug, pathname]);
 
   async function handleClose() {
     await window.cookieStore.set({


### PR DESCRIPTION
Marketing team requested that the banner doesn't display on the page it is linking to. I grabbed the pathname from "next/navigation" and added an additional check to the function that checks for the cookie.