### PR TITLE
fix: fixed clickable surface, updated tests

### DIFF
--- a/apps/web/features/page/blocks/header.tsx
+++ b/apps/web/features/page/blocks/header.tsx
@@ -54,7 +54,12 @@ export function HeaderBlock({ header, breadcrumb, className }: Props) {
         : 'primary';
 
     return (
-      <Button variant={variant} size="lg">
+      <Button
+        variant={variant}
+        size="lg"
+        asChild
+        className="md:cursor-pointer whitespace-nowrap"
+      >
         <CustomUrl
           className="outline-none"
           value={{

--- a/apps/web/tests/community.test.ts
+++ b/apps/web/tests/community.test.ts
@@ -21,7 +21,7 @@ test('Community', async ({ page }) => {
     );
 
     await expect(
-      section.getByRole('button', { name: 'Explore ecosystem' }),
+      section.getByRole('link', { name: 'Explore ecosystem' }),
     ).toBeVisible();
   });
 

--- a/apps/web/tests/developers.test.ts
+++ b/apps/web/tests/developers.test.ts
@@ -21,7 +21,11 @@ test('Developers', async ({ page }) => {
     );
 
     await expect(
-      section.getByRole('button', { name: 'Documentation' }),
+      section.getByRole('link', { name: 'Documentation' }),
+    ).toBeVisible();
+
+    await expect(
+      section.getByRole('link', { name: 'Ask other developers' }),
     ).toBeVisible();
   });
 

--- a/apps/web/tests/newsroom.test.ts
+++ b/apps/web/tests/newsroom.test.ts
@@ -51,14 +51,14 @@ test('Newsroom', async ({ page }) => {
       }),
     ).toBeVisible();
     await expect(
+      section.getByRole('link', { name: 'mubert goes web3' }),
+    ).toBeVisible();
+    await expect(
       section.getByRole('link', { name: 'copper and velocity labs' }),
     ).toBeVisible();
     await expect(
-      section.getByRole('link', { name: 'harbour and velocity labs launch' }),
-    ).toBeVisible();
-    await expect(
       section.getByRole('link', {
-        name: 'evrloot launches',
+        name: 'hyperbridge concludes',
       }),
     ).toBeVisible();
     await expect(


### PR DESCRIPTION
The full surface of header buttons was not clickable, only the text. (https://polkadot.com/get-started/dot-token/). Adding the asChild radix prop fixed the issue.