### PR TITLE
Fix: internal links to posts

### DIFF
--- a/apps/web/app/api/stats/static-metrics-store.ts
+++ b/apps/web/app/api/stats/static-metrics-store.ts
@@ -1,18 +1,18 @@
 // Auto-generated metrics from build process
-// Generated on: 2025-05-16T16:38:26.067Z
+// Generated on: 2025-05-28T14:06:48.449Z
 
 export const staticMetricsStore = {
   getActiveValidators: '600',
-  getApprovedReferendums: 891,
+  getApprovedReferendums: 903,
   getAverageMonthlyGovernanceVoters: 16955,
   getPercentDOTSupplyStaked: '54%',
   getPolkadotUptime30d: '100%',
   getTotalDOTStaked: '855816914.7304394',
-  getTotalFeesUSD30d: 498014.99042580667,
+  getTotalFeesUSD30d: 198489.10274795003,
   getTotalNominators: 31706,
-  getTotalReferendums: 1562,
-  getTotalStablecoinsUSD: 72826063.53939262,
-  getTotalStakers: 70640,
+  getTotalReferendums: 1581,
+  getTotalStablecoinsUSD: 73474953.26061119,
+  getTotalStakers: 70320,
   getTreasuryBalanceUSD: 51573300.16,
   getUniqueAccounts: 14022274,
 };

--- a/apps/web/components/custom-url.tsx
+++ b/apps/web/components/custom-url.tsx
@@ -35,11 +35,11 @@ export function CustomUrl({
     const parentSlug = (() => {
       switch (value?.internal?.post_type) {
         case BLOG_POSTTYPE:
-          return '/blog';
+          return 'blog';
         case PRESS_RELEASE_POSTTYPE:
-          return '/newsroom/press-releases';
+          return 'newsroom/press-releases';
         case CASE_STUDY_POSTTYPE:
-          return '/case-studies';
+          return 'case-studies';
         default:
           return '';
       }
@@ -77,7 +77,7 @@ export function CustomUrl({
   return value ? (
     <Link
       tabIndex={tabIndex}
-      href={value?.external || `${slug}` || ''}
+      href={value?.external || `/${slug}` || ''}
       target={value.external ? '_blank' : '_self'}
       className={className}
       prefetch={false}

--- a/apps/web/components/custom-url.tsx
+++ b/apps/web/components/custom-url.tsx
@@ -77,7 +77,7 @@ export function CustomUrl({
   return value ? (
     <Link
       tabIndex={tabIndex}
-      href={value?.external || `/${slug}` || ''}
+      href={value?.external || `${slug}` || ''}
       target={value.external ? '_blank' : '_self'}
       className={className}
       prefetch={false}


### PR DESCRIPTION
Internal links using the customURL component in Sanity were throwing a 404. The TLD was not being added due to an extra slash creating an absolute URL.