### PR TITLE
fix: add handling for when there are no terms - req for static gen

### DIFF
--- a/apps/web/app/(site)/glossary/[slug]/page.tsx
+++ b/apps/web/app/(site)/glossary/[slug]/page.tsx
@@ -14,7 +14,7 @@ import { Heading } from '@shared/ui';
 export async function generateStaticParams() {
   const slugs = await getAllGlossarySlugs();
 
-  if (!slugs?.length) return [];
+  if (!slugs?.length) return [{slug: 'not-found'}];
 
   return slugs.map((slug) => ({
     slug: slug,
@@ -46,7 +46,11 @@ export async function generateMetadata({
 }
 
 export default async function Page({ params }: { params: { slug: string } }) {
-  // const isDraftMode = draftMode().isEnabled
+
+  if (process.env.NEXT_PUBLIC_BUILD_TYPE === 'static') {
+    return notFound();
+  }
+  
   const data = await getGlossaryEntry(params.slug);
   if (!data) return notFound();
 

--- a/apps/web/app/api/stats/static-metrics-store.ts
+++ b/apps/web/app/api/stats/static-metrics-store.ts
@@ -1,19 +1,18 @@
 // Auto-generated metrics from build process
-
-// Generated on: 2025-05-28T14:06:48.449Z
+// Generated on: 2025-06-05T12:07:51.130Z
 
 export const staticMetricsStore = {
   getActiveValidators: '600',
-  getApprovedReferendums: 903,
-  getAverageMonthlyGovernanceVoters: 16955,
+  getApprovedReferendums: 905,
+  getAverageMonthlyGovernanceVoters: 16265,
   getPercentDOTSupplyStaked: '54%',
   getPolkadotUptime30d: '100%',
-  getTotalDOTStaked: '855816914.7304394',
-  getTotalFeesUSD30d: 198489.10274795003,
-  getTotalNominators: 31706,
-  getTotalReferendums: 1581,
-  getTotalStablecoinsUSD: 73474953.26061119,
-  getTotalStakers: 70320,
-  getTreasuryBalanceUSD: 51573300.16,
-  getUniqueAccounts: 14022274,
+  getTotalDOTStaked: '852516759.372461',
+  getTotalFeesUSD30d: 776016.4493529818,
+  getTotalNominators: 31276,
+  getTotalReferendums: 1586,
+  getTotalStablecoinsUSD: 48031804.77257664,
+  getTotalStakers: 70246,
+  getTreasuryBalanceUSD: 56218803.86,
+  getUniqueAccounts: 14372235,
 };


### PR DESCRIPTION
- if no glossary terms have dedicated page, static build would fail. this prevents static build from failing 