### PR TITLE
feat: updated press release page to use icons on post cards

### DIFF
--- a/apps/web/app/(site)/blog/page.tsx
+++ b/apps/web/app/(site)/blog/page.tsx
@@ -30,5 +30,5 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function Blog() {
-  return <Layout page={1} type={BLOG_POSTTYPE} tagSlug="" />;
+  return <Layout page={1} type={BLOG_POSTTYPE} tagSlug="" imageStyle="image" />;
 }

--- a/apps/web/app/(site)/blog/page/[page]/page.tsx
+++ b/apps/web/app/(site)/blog/page/[page]/page.tsx
@@ -55,7 +55,12 @@ export default async function Page({
 }) {
   return (
     <>
-      <Layout page={Number(page)} tagSlug="" type={BLOG_POSTTYPE} />
+      <Layout
+        page={Number(page)}
+        tagSlug=""
+        type={BLOG_POSTTYPE}
+        imageStyle="image"
+      />
       <Newsletter />
     </>
   );

--- a/apps/web/app/(site)/case-studies/page.tsx
+++ b/apps/web/app/(site)/case-studies/page.tsx
@@ -29,5 +29,7 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function CaseStudy() {
-  return <Layout page={1} type={CASE_STUDY_POSTTYPE} tagSlug="" />;
+  return (
+    <Layout page={1} type={CASE_STUDY_POSTTYPE} tagSlug="" imageStyle="image" />
+  );
 }

--- a/apps/web/app/(site)/case-studies/page/[page]/page.tsx
+++ b/apps/web/app/(site)/case-studies/page/[page]/page.tsx
@@ -58,7 +58,12 @@ export default async function Page({
 }) {
   return (
     <>
-      <Layout page={Number(page)} tagSlug="" type={CASE_STUDY_POSTTYPE} />
+      <Layout
+        page={Number(page)}
+        tagSlug=""
+        type={CASE_STUDY_POSTTYPE}
+        imageStyle="image"
+      />
       <Newsletter />
     </>
   );

--- a/apps/web/app/(site)/newsroom/press-releases/page.tsx
+++ b/apps/web/app/(site)/newsroom/press-releases/page.tsx
@@ -30,5 +30,12 @@ export async function generateMetadata(): Promise<Metadata> {
 }
 
 export default async function PressRelease() {
-  return <Layout page={1} type={PRESS_RELEASE_POSTTYPE} tagSlug="" />;
+  return (
+    <Layout
+      page={1}
+      type={PRESS_RELEASE_POSTTYPE}
+      tagSlug=""
+      imageStyle="icon"
+    />
+  );
 }

--- a/apps/web/app/(site)/newsroom/press-releases/page/[page]/page.tsx
+++ b/apps/web/app/(site)/newsroom/press-releases/page/[page]/page.tsx
@@ -56,6 +56,11 @@ export default async function Page({
   params: { page: string };
 }) {
   return (
-    <Layout page={Number(page)} tagSlug="" type={PRESS_RELEASE_POSTTYPE} />
+    <Layout
+      page={Number(page)}
+      tagSlug=""
+      type={PRESS_RELEASE_POSTTYPE}
+      imageStyle="icon"
+    />
   );
 }

--- a/apps/web/features/post/card.tsx
+++ b/apps/web/features/post/card.tsx
@@ -12,10 +12,11 @@ import { Card, CardContent, CardDescription, CardHeader, cn } from '@shared/ui';
 
 interface Props {
   post: TypeFromSelection<typeof postSelection>;
+  imageStyle?: 'image' | 'icon';
   className?: string;
 }
 
-export default function BlogCard({ post, className }: Props) {
+export default function BlogCard({ post, imageStyle, className }: Props) {
   const { slug, image, body, tags, title, post_type, custom_excerpt } = post;
 
   // Because not all blog posts have a custom excerpt imported
@@ -41,7 +42,7 @@ export default function BlogCard({ post, className }: Props) {
         className,
       )}
     >
-      {image && (
+      {image && imageStyle === 'image' && (
         <CardHeader className={cn('relative z-10 aspect-video')}>
           <Image
             src={image.asset.url}
@@ -54,6 +55,19 @@ export default function BlogCard({ post, className }: Props) {
         </CardHeader>
       )}
       <CardContent className="grid w-full p-card">
+        {image && imageStyle === 'icon' && (
+          <Image
+            src={image.asset.url}
+            alt=""
+            loading="lazy"
+            width={image.asset.metadata.dimensions?.width}
+            height={image.asset.metadata.dimensions?.height}
+            className={cn(
+              'relative z-10 ',
+              'mr-auto h-[4.5rem] w-auto rounded-2xl mb-6',
+            )}
+          />
+        )}
         {tags && (
           <ul className="mb-6 flex flex-wrap gap-3">
             {tags.map((tag) => (

--- a/apps/web/features/posts/grid.tsx
+++ b/apps/web/features/posts/grid.tsx
@@ -5,9 +5,10 @@ import BlogCard from '../post/card';
 
 interface Props {
   posts: ReadonlyArray<TypeFromSelection<typeof postSelection>>;
+  imageStyle?: 'image' | 'icon';
 }
 
-export function Grid({ posts }: Props) {
+export function Grid({ posts, imageStyle }: Props) {
   return (
     <div className="grid-system col-span-full mb-gutter gap-y-card md:gap-card">
       {posts.map((post) => {
@@ -16,7 +17,7 @@ export function Grid({ posts }: Props) {
             key={post._id}
             className="col-span-full md:col-span-3 lg:col-span-4"
           >
-            <BlogCard post={post} />
+            <BlogCard post={post} imageStyle={imageStyle} />
           </div>
         );
       })}

--- a/apps/web/features/posts/layout.tsx
+++ b/apps/web/features/posts/layout.tsx
@@ -26,6 +26,7 @@ interface LayoutProps {
     | typeof PRESS_RELEASE_POSTTYPE
     | typeof CASE_STUDY_POSTTYPE;
   tagSlug: string;
+  imageStyle: 'image' | 'icon';
   withHeader?: boolean;
 }
 
@@ -35,7 +36,12 @@ const SEARCH_INDEX_MAP = {
   [PRESS_RELEASE_POSTTYPE]: 'newsroom',
 };
 
-export default async function Layout({ page, tagSlug, type }: LayoutProps) {
+export default async function Layout({
+  page,
+  tagSlug,
+  type,
+  imageStyle,
+}: LayoutProps) {
   const data = await getPosts(page, type, tagSlug, false);
 
   const postType = (() => {
@@ -159,7 +165,7 @@ export default async function Layout({ page, tagSlug, type }: LayoutProps) {
           </div>
 
           <section className="col-span-full">
-            <Grid posts={data.posts} />
+            <Grid posts={data.posts} imageStyle={imageStyle} />
           </section>
 
           <PostPagination

--- a/apps/web/sanity/schemas/documents/posts/post.ts
+++ b/apps/web/sanity/schemas/documents/posts/post.ts
@@ -79,7 +79,8 @@ export default defineType({
     defineField({
       name: 'featured_image',
       title: 'Featured Image',
-      description: 'Only for blog posts',
+      description:
+        'Standard 16:9 image for blogs and case studies, and a 1:1 icon for press releases.',
       type: 'image',
       group: 'content',
     }),


### PR DESCRIPTION
- Updates the cards on the press release page to use icons instead of traditional header images so we can get press releases out faster.